### PR TITLE
Update bloom player files for compatibility with Kolibri

### DIFF
--- a/src/bloom-player-controls.tsx
+++ b/src/bloom-player-controls.tsx
@@ -45,6 +45,8 @@ interface IProps {
     // e.g. if title is C#, url should be http://localhost:8089/bloom/C:/PathToTemp/PlaceForStagingBook/C%23
     // (Not "[...]/C#" nor "[...]%2FC%2523", and most certainly not with any XML (entity) encoding)
     url: string;
+    distributionUrl?: string;
+    metaJsonUrl?: string;
     initiallyShowAppBar: boolean;
     allowToggleAppBar: boolean;
     showBackButton: boolean;
@@ -933,6 +935,8 @@ export const BloomPlayerControls: React.FunctionComponent<IProps &
                 // We believe/hope we can do this a better way (without LegacyRef) once BloomPlayerCore is a function component.
                 ref={coreRef as LegacyRef<BloomPlayerCore>}
                 url={props.url}
+                distributionUrl={props.distributionUrl}
+                metaJsonUrl={props.metaJsonUrl}
                 landscape={windowLandscape}
                 paused={paused}
                 preferredUiLanguages={preferredUiLanguages}
@@ -1123,6 +1127,10 @@ export function InitBloomPlayerControls() {
                 roundMarginToNearestK={getNumericUrlParam(
                     "roundMarginToNearestK"
                 )}
+                distributionUrl={getQueryStringParamAndUnencode(
+                    "distributionUrl"
+                )}
+                metaJsonUrl={getQueryStringParamAndUnencode("metaJsonUrl")}
             />
         </ThemeProvider>,
         document.getElementById("root")

--- a/src/externalContext.ts
+++ b/src/externalContext.ts
@@ -43,7 +43,9 @@ export function sendMessageToHost(messageObj: WithMessageType) {
     // receives the message.
     // This is probably not used now, but if we ever did, it now sends a messageType as well.
     if (window.parent) {
-        window.parent.postMessage(message, "*"); // any window may receive
+        messageObj["nameSpace"] = "BloomPlayer";
+        messageObj["data"] = messageObj["params"];
+        window.parent.postMessage(messageObj, "*"); // any window may receive
     }
 }
 

--- a/src/music.ts
+++ b/src/music.ts
@@ -148,9 +148,12 @@ export class Music {
         // so it will cache the previous content of the file or
         // remember if no such file previously existed. So we add a bogus query string
         // based on the current time so that it asks the server for the file again.
-        const url = this.currentMusicUrl(
+        let url = this.currentMusicUrl(
             music + "?nocache=" + new Date().getTime()
         );
+        if (url.startsWith("blob")) {
+            url = this.currentMusicUrl(music);
+        }
         const player = this.getPlayer();
         player.setAttribute("src", music ? url : "");
         if (volume.length) {
@@ -178,7 +181,15 @@ export class Music {
     private musicLogIndex = -1;
 
     private currentMusicUrl(filename: string): string {
-        return this.urlPrefix + "/audio/" + filename;
+        let result = this.urlPrefix + "/audio/" + filename;
+        if (filename.startsWith("_")) {
+            result =
+                "blob:http://" +
+                this.urlPrefix.split("/").at(-2) +
+                "/" +
+                filename.substring(1);
+        }
+        return result;
     }
 
     private playEnded() {

--- a/src/narration.ts
+++ b/src/narration.ts
@@ -964,14 +964,25 @@ function updatePlayerStatus() {
     // tool and haven't recorded anything yet). So we just try to play it and see what happens.
     // The optional param tells Bloom not to report an error if the file isn't found, and is ignored in
     // other contexts.
-    player.setAttribute(
-        "src",
-        url + "?nocache=" + new Date().getTime() + "&optional=true"
-    );
+    if (url.startsWith("blob")) player.setAttribute("src", url);
+    else
+        player.setAttribute(
+            "src",
+            url + "?nocache=" + new Date().getTime() + "&optional=true"
+        );
 }
 
 function currentAudioUrl(id: string): string {
-    const result = urlPrefix() + "/audio/" + id + ".mp3";
+    let result = urlPrefix() + "/audio/" + id + ".mp3";
+    if (id.startsWith("_")) {
+        result =
+            "blob:http://" +
+            urlPrefix()
+                .split("/")
+                .at(-2) +
+            "/" +
+            id.substring(1);
+    }
     return result;
 }
 


### PR DESCRIPTION
## Summary:
Updated the props to accept URLs for `.distribution` and `meta.json`, and handled cases where Kolibri parses and updates the blob URLs.

## References:
[#36](https://github.com/learningequality/kolibri-ecosystem/issues/36)
[#12237](https://github.com/learningequality/kolibri/issues/12237)