### PR TITLE
updated bloom-player assests with improved navigation button opacity

### DIFF
--- a/src/bloom-player-ui.less
+++ b/src/bloom-player-ui.less
@@ -115,7 +115,7 @@ We just make them follow the main content normally. */
         // This makes the grey buttons, which are all you can see when not hovering,
         // quite faint, allowing all the page content to be seen through them,
         // when not hovered over; yet there is some hint of something to click.
-        opacity: 0.6;
+        opacity: 0.85;
         // the actual background-url is set in blocks not shared by next/prev
         background-repeat: no-repeat;
         background-size: 4mm;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- This PR addresses the issue where the Bloom Player’s previous and next navigation arrows appear disabled due to low opacity.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Related to https://github.com/learningequality/kolibri/issues/12779

## Before
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

![image](https://github.com/user-attachments/assets/e82e1ce8-9aae-4f9b-9792-ac027c79fb2e)

## After 
![image](https://github.com/user-attachments/assets/5dba9da7-4619-486f-b1f5-75411bd45b78)


