### PR TITLE
Add support for questionsJsonUrl

### DIFF
--- a/src/activities/legacyQuizHandling/LegacyQuizHandler.ts
+++ b/src/activities/legacyQuizHandling/LegacyQuizHandler.ts
@@ -5,11 +5,16 @@ import { OldQuestionsConverter } from "./old-questions";
 // "questions.json" was the trigger to make pages at the end.
 
 export class LegacyQuestionHandler {
-    public constructor(locationOfDistFolder: string) {
+    public constructor(
+        locationOfDistFolder: string,
+        questionsJsonUrl?: string
+    ) {
         this.locationOfDistFolder = locationOfDistFolder;
+        this.questionsJsonUrl = questionsJsonUrl;
     }
     private needQuizCss = false;
     private locationOfDistFolder: string;
+    private questionsJsonUrl?: string;
     public getPromiseForAnyQuizCss() {
         return this.needQuizCss
             ? // enhance: we would like to change this name to "simpleComprehensionQuiz.css", but
@@ -29,7 +34,8 @@ export class LegacyQuestionHandler {
         pageClass,
         finished: () => void
     ) {
-        const urlOfQuestionsFile = urlPrefix + "/questions.json";
+        const urlOfQuestionsFile =
+            this.questionsJsonUrl || urlPrefix + "/questions.json";
         axios
             .get(urlOfQuestionsFile)
             .then(qfResult => {

--- a/src/bloom-player-controls.tsx
+++ b/src/bloom-player-controls.tsx
@@ -47,6 +47,7 @@ interface IProps {
     url: string;
     distributionUrl?: string;
     metaJsonUrl?: string;
+    questionsJsonUrl?: string;
     initiallyShowAppBar: boolean;
     allowToggleAppBar: boolean;
     showBackButton: boolean;
@@ -938,6 +939,7 @@ export const BloomPlayerControls: React.FunctionComponent<IProps &
                 url={props.url}
                 distributionUrl={props.distributionUrl}
                 metaJsonUrl={props.metaJsonUrl}
+                questionsJsonUrl={props.questionsJsonUrl}
                 landscape={windowLandscape}
                 paused={paused}
                 preferredUiLanguages={preferredUiLanguages}
@@ -1132,6 +1134,9 @@ export function InitBloomPlayerControls() {
                     "distributionUrl"
                 )}
                 metaJsonUrl={getQueryStringParamAndUnencode("metaJsonUrl")}
+                questionsJsonUrl={getQueryStringParamAndUnencode(
+                    "questionsJsonUrl"
+                )}
             />
         </ThemeProvider>,
         document.getElementById("root")

--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -89,6 +89,7 @@ interface IProps {
     url: string;
     distributionUrl?: string;
     metaJsonUrl?: string;
+    questionsJsonUrl?: string;
     landscape: boolean; // whether viewing as landscape or portrait
     // ``paused`` allows the parent to control pausing of audio. We expect we may supply
     // a click/touch event callback if needed to support pause-on-touch.
@@ -279,7 +280,8 @@ export class BloomPlayerCore extends React.Component<IProps, IState> {
         // notifications from narration.ts etc about duration etc.
         BloomPlayerCore.currentPagePlayer = this;
         this.legacyQuestionHandler = new LegacyQuestionHandler(
-            props.locationOfDistFolder
+            props.locationOfDistFolder,
+            props.questionsJsonUrl
         );
     }
 


### PR DESCRIPTION
## Summary

* Add support for `questionsJsonUrl` prop from the url query params. This is to have an alternative way of passing the `question.json` url file from a blob url.

## References

Needed to fix https://github.com/learningequality/kolibri/issues/13339.
